### PR TITLE
Small installation and monitor plugins fixes

### DIFF
--- a/autopyfactory/factory.py
+++ b/autopyfactory/factory.py
@@ -561,9 +561,11 @@ class Factory(object):
         #            monitor_plugin = pluginmanager.getplugin(self, ['autopyfactory', 'plugins', 'factory', 'monitor'], monitorpluginname, self.mcl, monitorsection)        # a list of 1 or more plugins
         #            self.monitor_plugins.append(monitor_plugin)
         ### BEGIN NEW ###
-        monitorpluginnames = self.fcl.generic_get('Factory', 'monitor', default_value=[])
-        monitorpluginnames_l = [i.strip() for i in monitorpluginnames.split(',')]
-        self.monitor_plugins = pluginmanager.getpluginlist(['autopyfactory','plugins','factory','monitor'], monitorpluginnames_l, self, self.fcl, 'Factory')
+	self.monitor_plugins = []
+        monitorpluginnames = self.fcl.generic_get('Factory', 'monitor', default_value=None)
+	if monitorpluginnames is not None:
+		monitorpluginnames_l = [i.strip() for i in monitorpluginnames.split(',')]
+		self.monitor_plugins = pluginmanager.getpluginlist(['autopyfactory','plugins','factory','monitor'], monitorpluginnames_l, self, self.fcl, 'Factory')
         ### END TEST ###
 
 

--- a/setup.py
+++ b/setup.py
@@ -73,21 +73,20 @@ home_data_files=[#('etc', libexec_files),
 
 # -----------------------------------------------------------
 
-def choose_data_files():
-    rpminstall = True
-    userinstall = False 
-     
-    if 'bdist_rpm' in sys.argv:
-        rpminstall = True
-        userinstall = False
-                
-    if rpminstall:
-        return rpm_data_files
-    elif userinstall:
+def choose_data_file_locations():
+    local_install = False
+
+    if '--user' in sys.argv:
+        local_install = True
+    elif any([re.match('--home(=|\s)', arg) for arg in sys.argv]):
+        local_install = True
+    elif any([re.match('--prefix(=|\s)', arg) for arg in sys.argv]):
+        local_install = True
+
+    if local_install:
         return home_data_files
     else:
-        # Something probably went wrong, so punt
-        return home_data_files
+        return rpm_data_files
        
 # ===========================================================
 
@@ -127,5 +126,5 @@ setup(
                'bin/proxymanager'
               ],
     
-    data_files = choose_data_files()
+    data_files = choose_data_file_locations()
 )


### PR DESCRIPTION
When installing, setup.py runs several times, with some of the
arguments, such as bdist_rpm disappearing. This causes errors when
choosing the data file location. The current commit fixes that.