### PR TITLE
Remotemanager

### DIFF
--- a/BRANCHES
+++ b/BRANCHES
@@ -43,3 +43,5 @@ config-plugins             code to deal with the new plugins to read queues conf
 plugin-dispatcher          new code for plugins management, more generic 
 
 2.4.3-1-ec2fixed           2.4.3 patched to fix some bugs found during the "100k core @ EC2" exercise. Same fixes also go into trunk/
+
+remotemanager              test branch to replace Bosco with VC3 Remote Manager

--- a/autopyfactory/plugins/queue/batchsubmit/CondorSSH.py
+++ b/autopyfactory/plugins/queue/batchsubmit/CondorSSH.py
@@ -1,6 +1,6 @@
 #!/bin/env python
 #
-# AutoPyfactory batch plugin for Condor
+# AutoPyfactory shim for VC3 remote manager
 #
 #
 # At init
@@ -72,9 +72,8 @@ class CondorSSH(CondorBase):
             self._createSSHConfig()
             
             #Handle bosco
-            self.boscocli = bosco.BoscoCLI()
-            self.boscocli._checkbosco()
-            self.boscocli._checktarget(self.user,
+            self.rgahp = remotemanager.Manage()
+            self.rgahp._checktarget(self.user,
                                        self.host, 
                                        self.port, 
                                        self.batch, 

--- a/autopyfactory/plugins/queue/batchsubmit/CondorSSH.py
+++ b/autopyfactory/plugins/queue/batchsubmit/CondorSSH.py
@@ -74,7 +74,8 @@ class CondorSSH(CondorBase):
             #Handle bosco
             self.log.debug("calling remote manager with options %s , %s , %s , %s , %s , %s , %s" % (self.user, self.host, self.port, self.batch, self.pubkeyfile, self.privkeyfile, self.passfile))
             self.rgahp = remotemanager.Manage()
-            self.rgahp._checktarget(self.user,
+            # rgahp._checktarget returns the glite installation dir
+            self.glite = self.rgahp._checktarget(self.user,
                                        self.host, 
                                        self.port, 
                                        self.batch, 
@@ -158,12 +159,13 @@ class CondorSSH(CondorBase):
         
         self.log.debug('CondorBosco.addJSD: Starting.')
         self.JSD.add("universe", "grid")
-        self.JSD.add('grid_resource', 'batch %s %s@%s --rgahp-key %s ' % (self.batch, 
+        self.JSD.add('grid_resource', 'batch %s %s@%s --rgahp-key %s --rgahp-glite %s ' % (self.batch, 
                                                           self.user,
                                                           self.host, 
                                                           #self.port,
                                                           self.privkeyfile, 
-                                                          #self.passfile
+                                                          #self.passfile,
+                                                          self.glite
                                                           ) )
         self.JSD.add('+TransferOutput', '""')
         super(CondorSSH, self)._addJSD()

--- a/autopyfactory/plugins/queue/batchsubmit/CondorSSH.py
+++ b/autopyfactory/plugins/queue/batchsubmit/CondorSSH.py
@@ -34,7 +34,7 @@ import os
 import shutil
 
 from autopyfactory import jsd
-from autopyfactory import bosco
+from autopyfactory import remotemanager
 from CondorBase import CondorBase
 
 class CondorSSH(CondorBase):

--- a/autopyfactory/plugins/queue/batchsubmit/CondorSSH.py
+++ b/autopyfactory/plugins/queue/batchsubmit/CondorSSH.py
@@ -72,6 +72,7 @@ class CondorSSH(CondorBase):
             self._createSSHConfig()
             
             #Handle bosco
+            self.log.debug("calling remote manager with options %s , %s , %s , %s , %s , %s , %s" % (self.user, self.host, self.port, self.batch, self.pubkeyfile, self.privkeyfile, self.passfile))
             self.rgahp = remotemanager.Manage()
             self.rgahp._checktarget(self.user,
                                        self.host, 

--- a/autopyfactory/plugins/queue/batchsubmit/CondorSSH.py
+++ b/autopyfactory/plugins/queue/batchsubmit/CondorSSH.py
@@ -1,6 +1,6 @@
 #!/bin/env python
 #
-# AutoPyfactory shim for VC3 remote manager
+# AutoPyfactory batch plugin for Condor
 #
 #
 # At init

--- a/autopyfactory/remotemanager.py
+++ b/autopyfactory/remotemanager.py
@@ -1,0 +1,38 @@
+#!/bin/env python
+
+from vc3remotemanager.ssh import SSHmanager
+from vc3remotemanager.cluster import Cluster
+from vc3remotemanager.bosco import Bosco
+
+class Manage(object):
+    """
+    Set up remote target
+    """
+
+    def _checktarget(self, user, host, port, batch, pubkeyfile, privkeyfile, passfile=None):
+        """
+        Ensure remote_manager has set up rgahp
+        """
+        #Ensure paths
+        pubkeyfile = os.path.expanduser(pubkeyfile)
+        privkeyfile = os.path.expanduser(privkeyfile)
+        try:
+            passfile = os.path.expanduser(passfile)
+        except AttributeError:
+            pass
+
+        # set up paramiko and stuff
+        ssh = SSHManager(host, port, user, privkeyfile)
+        cluster = Cluster(ssh)
+        bosco = Bosco(cluster, ssh, batch, "1.2.10", "ftp://ftp.cs.wisc.edu/condor/bosco", None, "/tmp/bosco", "~/.condor", None, None, None, None)
+        
+        self.log.debug("Checking to see if remote gahp is installed and up to date...")
+        try:
+            clusters = bosco.get_clusters()
+            entry = user + "@" + host
+            if entry in clusters:
+                self.log.debug("Cluster %s is already setup:" % entry)
+            else:
+                bosco.setup_bosco()
+        except Exception, e:
+            self.log.exception("Exception during bosco remote installation. ")

--- a/autopyfactory/remotemanager.py
+++ b/autopyfactory/remotemanager.py
@@ -48,12 +48,13 @@ class Manage(object):
             if entry in clusters:
                 self.log.debug("Cluster %s is already setup:" % entry)
             else:
+                self.log.debug("Didn't find cluster %s, installing..." % entry)
                 bosco.setup_bosco()
         except Exception, e:
             self.log.exception("Exception during bosco remote installation. ")
 
 if __name__ == '__main__':
-        # some simple tests
+    # some simple tests
 	host = "uct3-s1.mwt2.org"
 	port = 22
 	user = "lincolnb"

--- a/autopyfactory/remotemanager.py
+++ b/autopyfactory/remotemanager.py
@@ -35,11 +35,13 @@ class Manage(object):
         except AttributeError:
             pass
 
+        installdir = "~/.condor"
+
         # set up paramiko and stuff
         ssh = SSHManager(host, port, user, privkeyfile)
         cluster = Cluster(ssh)
 	# fixme - move these into defaults
-        bosco = Bosco(cluster, ssh, batch, "1.2.10", "ftp://ftp.cs.wisc.edu/condor/bosco", None, "/tmp/bosco", "~/.condor", None, None, None, None)
+        bosco = Bosco(cluster, ssh, batch, "1.2.10", "ftp://ftp.cs.wisc.edu/condor/bosco", None, "/tmp/bosco", installdir, None, None, None, None)
         
         self.log.debug("Checking to see if remote gahp is installed and up to date...")
         try:
@@ -52,6 +54,10 @@ class Manage(object):
                 bosco.setup_bosco()
         except Exception, e:
             self.log.exception("Exception during bosco remote installation. ")
+
+        # add a return for the location of the glite installation
+        glite = installdir + "/bosco/glite"
+        return glite
 
 if __name__ == '__main__':
     # some simple tests

--- a/autopyfactory/remotemanager.py
+++ b/autopyfactory/remotemanager.py
@@ -1,13 +1,27 @@
 #!/bin/env python
 
-from vc3remotemanager.ssh import SSHmanager
+import logging
+import os
+
+from vc3remotemanager.ssh import SSHManager
 from vc3remotemanager.cluster import Cluster
 from vc3remotemanager.bosco import Bosco
+
+# Added to support running module as script from arbitrary location.
+from os.path import dirname, realpath, sep, pardir
+fullpathlist = realpath(__file__).split(sep)
+prepath = sep.join(fullpathlist[:-2])
+import sys
+sys.path.insert(0, prepath)
 
 class Manage(object):
     """
     Set up remote target
     """
+
+    def __init__(self):
+	self.log = logging.getLogger('autopyfactory')
+	self.log.debug("Initializing remote manager module...")
 
     def _checktarget(self, user, host, port, batch, pubkeyfile, privkeyfile, passfile=None):
         """
@@ -24,6 +38,7 @@ class Manage(object):
         # set up paramiko and stuff
         ssh = SSHManager(host, port, user, privkeyfile)
         cluster = Cluster(ssh)
+	# fixme - move these into defaults
         bosco = Bosco(cluster, ssh, batch, "1.2.10", "ftp://ftp.cs.wisc.edu/condor/bosco", None, "/tmp/bosco", "~/.condor", None, None, None, None)
         
         self.log.debug("Checking to see if remote gahp is installed and up to date...")
@@ -36,3 +51,55 @@ class Manage(object):
                 bosco.setup_bosco()
         except Exception, e:
             self.log.exception("Exception during bosco remote installation. ")
+
+if __name__ == '__main__':
+        # some simple tests
+	host = "uct3-s1.mwt2.org"
+	port = 22
+	user = "lincolnb"
+	privkeyfile = "/home/autopyfactory/etc/autopyfactory/auth/lincolnb.uchicago-uct3/ssh-rsa"
+	pubkeyfile = "/home/autopyfactory/etc/autopyfactory/auth/lincolnb.uchicago-uct3/ssh-rsa.pub"
+	batch = "condor"
+
+	# Set up logging.
+	debug = True
+	info = 0
+
+	# Check python version
+	major, minor, release, st, num = sys.version_info
+
+	# Set up logging, handle differences between Python versions...
+	# In Python 2.3, logging.basicConfig takes no args
+	#
+	FORMAT23="[ %(levelname)s ] %(asctime)s %(filename)s (Line %(lineno)d): %(message)s"
+	FORMAT24=FORMAT23
+	FORMAT25="[%(levelname)s] %(asctime)s %(module)s.%(funcName)s(): %(message)s"
+	FORMAT26=FORMAT25
+
+	if major == 2:
+		if minor ==3:
+		    formatstr = FORMAT23
+		elif minor == 4:
+		    formatstr = FORMAT24
+		elif minor == 5:
+		    formatstr = FORMAT25
+		elif minor == 6:
+		    formatstr = FORMAT26
+		elif minor == 7:
+		    formatstr = FORMAT26
+
+	log = logging.getLogger('autopyfactory')
+	hdlr = logging.StreamHandler(sys.stdout)
+	formatter = logging.Formatter(FORMAT23)
+	hdlr.setFormatter(formatter)
+	log.addHandler(hdlr)
+
+	if debug:
+		log.setLevel(logging.DEBUG) # Override with command line switches
+	if info:
+		log.setLevel(logging.INFO) # Override with command line switches
+	log.debug("Logging initialized.")
+
+
+	b = Manage()
+	b._checktarget(user, host, port, batch, pubkeyfile, privkeyfile, None)


### PR DESCRIPTION
<old content was removed, bug was fixed>
this replaces the bosco plugin with the remote manager plugin. one significant difference is that _checktarget now returns the glite install location on the remote side. 