### PR TITLE
Add GlobalJobID

### DIFF
--- a/autopyfactory/plugins/queue/batchstatus/Condor.py
+++ b/autopyfactory/plugins/queue/batchstatus/Condor.py
@@ -47,6 +47,7 @@ class CondorJobInfo(object):
                 'ec2securitygroups',
                 'ec2spotprice',
                 'gridjobstatus',
+                'globaljobid',
                  ]  
 
 


### PR DESCRIPTION
It would be helpful to have the GlobalJobId in the Condor job info object.